### PR TITLE
release-tags.sh: Cleanup shell script.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sh]
+#shell_variant      = posix
+binary_next_line   = true
+switch_case_indent = true
+space_redirects    = true
+keep_padding       = true
+#function_next_line = true

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,7 @@ name: 'Github Release Tags'
 description:
   Parse git version tag, branch and generate publishable tags that identify the
   current build.
+
 inputs:
   tags-prefix:
     description:
@@ -19,6 +20,7 @@ inputs:
       Always generate the "latest" tag when executing on the specified branch.
     required: false
     default: ''
+
 outputs:
   version:
     description: "Tag pointing to the current commit as obtained from `git describe`"
@@ -31,6 +33,7 @@ outputs:
       Tags that should be published for the current build. Includes `version`,
       `branches` and potentially "latest" if version is a stable semver.
     value: ${{ steps.release-tags.outputs.tags }}
+
 runs:
   using: "composite"
   steps:

--- a/release-tags.sh
+++ b/release-tags.sh
@@ -7,47 +7,45 @@ FORCE_LATEST=${FORCE_LATEST:-false}
 ALWAYS_LATEST_ON_BRANCH=${ALWAYS_LATEST_ON_BRANCH:-""}
 
 function getBranches() {
-  GH_REF=${GITHUB_HEAD_REF:-$GITHUB_REF}
-  if [[ $GH_REF == refs/heads/* ]]; then
-    GH_REF=${GH_REF#refs/heads/}
+  local gh_ref=${GITHUB_HEAD_REF:-$GITHUB_REF}
+  if [[ $gh_ref == refs/heads/* ]]; then
+    gh_ref=${gh_ref#refs/heads/}
   else
-    GH_REF=$(git branch -a --points-at HEAD \
-        | sed -e 's/^[\* ]*//' -e 's/^remotes\/origin\///' -e '/HEAD /d' \
-        | sort | uniq)
+    gh_ref=$(git branch -a --points-at HEAD | sed -e 's/^[\* ]*//;s:^remotes/origin/::;/HEAD /d' | sort -u)
   fi
 
-  for branch in $GH_REF; do
-    printf "$branch" | sed 's/\//-/g' | tr -cd '[:alnum:]_-'
+  for branch in $gh_ref; do
+    printf "$branch" | sed 's:/:-:g' | tr -cd '[:alnum:]_-'
     printf " "
   done
 }
 
 function getTags() {
-  PREFIX=$TAGS_PREFIX
-  VERSION=$1
-  BRANCHES=$2
+  local prefix=$TAGS_PREFIX
+  local version=$1
+  local branches=$2
 
-  for branch in $BRANCHES; do
+  for branch in $branches; do
     if [[ "$branch" = "$ALWAYS_LATEST_ON_BRANCH" ]]; then
       FORCE_LATEST="true"
     fi
   done
 
-  if [[ $VERSION =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ || "$FORCE_LATEST" = "true" ]]; then
-    echo "${PREFIX:-latest}"
+  if [[ $version =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ || "$FORCE_LATEST" = "true" ]]; then
+    echo "${prefix:-latest}"
   fi
-  for tag in $VERSION $BRANCHES; do
-    if [[ -z "$PREFIX" || "$tag" = "$PREFIX" ]]; then
+  for tag in $version $branches; do
+    if [[ -z "$prefix" || "$tag" = "$prefix" ]]; then
       echo "$tag"
     else
-      echo "$PREFIX-$tag"
+      echo "${prefix}-${tag}"
     fi
   done
 }
 
 VERSION=$(git describe --tag --dirty)
 BRANCHES=$(getBranches)
-TAGS=$(getTags "$VERSION" "$BRANCHES" | sort | uniq | tr '\n' ' ')
+TAGS=$(getTags "$VERSION" "$BRANCHES" | sort -u | tr '\n' ' ')
 
 echo "::set-output name=version::$VERSION"
 echo "::set-output name=branches::$BRANCHES"


### PR DESCRIPTION
 - Few changes to the action script.
 - Use `sort` provided flag to filter out unique values.
 - Shorter `sed` command.
 - Define local variables inside functions